### PR TITLE
Upgrade to Ember to 1.11.0(-beta.5)

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <div class="app-bar">
   <div class="gutter" {{action "toggleNavBar"}}>
-    <i {{bind-attr class=":icon-menu showingNavBar:rotate-cw"}}></i>
+    <i class="icon-menu {{if showingNavBar "rotate-cw"}}"></i>
   </div>
   <h1>Hacker News</h1>
 </div>
@@ -39,7 +39,7 @@
   {{/link-to}}
 </nav>
 
-<div {{bind-attr class=":app-main showingNavBar:slide-out"}}>
+<div class="app-main {{if showingNavBar "slide-out"}}">
   {{outlet}}
 </div>
 

--- a/app/templates/components/comment-card.hbs
+++ b/app/templates/components/comment-card.hbs
@@ -3,7 +3,7 @@
   <span class="submitted">{{link-to comment.submitted (query-params highlight=comment.id)}}</span>
 </div>
 
-<div class="body" {{bind-attr style=bodyStyle}}>{{comment.body}}</div>
+<div class="body" style="{{bodyStyle}}">{{comment.body}}</div>
 
 {{#if comment.comments}}
 

--- a/app/templates/components/story-card.hbs
+++ b/app/templates/components/story-card.hbs
@@ -2,7 +2,7 @@
 
 {{#if story.source}}
   <div class="source">
-    <a {{bind-attr href=story.url}} target="_blank" class="source-link">{{story.source}}</a>
+    <a href="{{story.url}}" target="_blank" class="source-link">{{story.source}}</a>
   </div>
 {{/if}}
 

--- a/app/templates/preferences.hbs
+++ b/app/templates/preferences.hbs
@@ -16,7 +16,7 @@
       </label>
     </div>
 
-    <div {{bind-attr class=":row preferences.autoFold::hidden"}}>
+    <div class="row {{unless preferences.autoFold "hidden"}}">
       <h5>Folding Threshold</h5>
 
       {{#if topLevelOnly}}

--- a/app/templates/stories.hbs
+++ b/app/templates/stories.hbs
@@ -10,6 +10,6 @@
   </ol>
 </div>
 
-<div {{bind-attr class=":app-content hasContent:active"}}>
+<div class="app-content {{if hasContent "active"}}">
   {{outlet}}
 </div>

--- a/app/templates/stories/show.hbs
+++ b/app/templates/stories/show.hbs
@@ -18,7 +18,7 @@
     {{/unless}}
   </div>
 
-  <div {{bind-attr class=":story-reader-content isInternal:internal"}}>
+  <div class="story-reader-content {{if isInternal "internal"}}">
     {{outlet}}
   </div>
 </div>

--- a/app/templates/stories/show/article.hbs
+++ b/app/templates/stories/show/article.hbs
@@ -13,7 +13,7 @@
       </p>
     {{/if}}
 
-    <p><a {{bind-attr href=url}} target="_blank">View original</a></p>
+    <p><a href="{{url}}" target="_blank">View original</a></p>
   </div>
 {{else}}
   <article>

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "hn-reader",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.10.0",
+    "ember": "1.11.0-beta.5",
     "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.12",
     "entypo-plus": "chancancode/entypo-plus",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
-    "ember-inflector": "1.3.1"
+    "ember-inflector": "1.3.1",
+    "glob": "4.0.5"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
WIP, do not merge!
## Things TODO
- [ ] Using store.fetch() has been deprecated. Use store.fetchById for fetching individual records or store.fetchAll for collections
- [ ] Ember.ObjectController is deprecated, please use Ember.Controller and use `model.propertyName`.
- [ ] You attempted to access `null` from `<hn-reader@controller:stories/show::ember1303>`, but object proxying is deprecated. Please use `model.null` instead.
- [x] Change all `bind-attr` to the new `attr=prop` syntax
