### PR TITLE
Explicitly Set 'mapped' Location Type

### DIFF
--- a/app/routes/stories/show.js
+++ b/app/routes/stories/show.js
@@ -22,7 +22,7 @@ export default Ember.Route.extend({
   },
 
   model(params) {
-    return this.store.fetch('story', params.story_id);
+    return this.store.fetchById('story', params.story_id);
   },
 
   afterModel(story) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function(environment) {
     modulePrefix: 'hn-reader',
     environment: environment,
     baseURL: '/',
-    locationType: 'auto',
+    locationType: 'mapped',
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
-    "ember-inflector": "1.3.1"
+    "ember-inflector": "1.3.1",
+    "glob": "4.0.5"
   },
   "ember-addon": {
     "paths": [

--- a/tests/unit/initializers/04-url-mapper-test.js
+++ b/tests/unit/initializers/04-url-mapper-test.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+import { initialize } from '../../../initializers/04-url-mapper';
+import { module, test } from 'qunit';
+
+var container, application;
+
+module('04UrlMapperInitializer', {
+  beforeEach: function() {
+    Ember.run(function() {
+      application = Ember.Application.create();
+      container = application.__container__;
+      application.deferReadiness();
+    });
+  }
+});
+
+// Replace this with your real tests.
+test('location:mapped registered on initialize', function(assert) {
+  initialize(container, application);
+
+  assert.equal(container.resolve('location:mapped'), '(subclass of Ember.HistoryLocation)');
+});


### PR DESCRIPTION
Should resolve a bug which crashes the app when running as a
Chrome extension, due to the Ember router not using the correct
location adapter.

Also, small fix to deprecated `store.fetch` method.
