### PR TITLE
Error: Cannot find module 'glob'

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
-    "ember-inflector": "1.3.1"
+    "ember-inflector": "1.3.1",
+    "glob": "^5.0.3"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
a fresh clone and npm install shows an error with missing package. 

This PR Adds glob module to package.json

![screen shot 2015-03-14 at 3 16 52 pm](https://cloud.githubusercontent.com/assets/955736/6653837/75bece9e-ca5d-11e4-8b04-f474d63ea264.png)
