### PR TITLE
Install depends on the `glob` package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ember-cli-uglify": "1.0.1",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
-    "ember-inflector": "1.3.1"
+    "ember-inflector": "1.3.1",
+    "glob": "5.0.3"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
When running `npm install` I get the following error:

```
$ npm install
npm WARN package.json ember-inflector@1.3.1 No repository field.

> hn-reader@0.0.0 postinstall /Users/josh/code/js/edge/hn-reader
> node lib/install

module.js:338
    throw err;
          ^
Error: Cannot find module 'glob'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/josh/code/js/edge/hn-reader/lib/install.js:2:12)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
```
